### PR TITLE
Improve UI with theme toggle and modern header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,7 +20,9 @@
 }
 
 body {
-  background: var(--background);
+  background: linear-gradient(to bottom right, var(--background), #f1f5f9);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), sans-serif;
+  min-height: 100vh;
+  transition: background-color 0.3s, color 0.3s;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Header from "@/components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Header />
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -144,7 +144,6 @@ export default function Home() {
 
   return (
     <main className="flex min-h-screen flex-col items-center p-6 md:p-24 space-y-6">
-      <h1 className="text-3xl md:text-4xl font-bold text-center">Live Fact-Checker</h1>
       <AudioCapture
         isProcessing={isBusy}
         onProcessingChange={handleProcessingAudioChange}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,11 @@
+'use client';
+import ThemeToggle from './ThemeToggle';
+
+export default function Header() {
+  return (
+    <header className="w-full flex items-center justify-between py-4 px-6 bg-white/60 dark:bg-black/40 backdrop-blur border-b border-gray-200 dark:border-gray-800 sticky top-0 z-10">
+      <h1 className="text-lg font-semibold tracking-tight">Live Fact-Checker</h1>
+      <ThemeToggle />
+    </header>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') {
+      document.documentElement.classList.add('dark');
+      setTheme('dark');
+    } else if (stored === 'light') {
+      document.documentElement.classList.remove('dark');
+      setTheme('light');
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+      setTheme('dark');
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === 'light' ? 'dark' : 'light';
+    setTheme(next);
+    if (next === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    localStorage.setItem('theme', next);
+  };
+
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+      className="p-2 rounded-md bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+    >
+      {theme === 'light' ? '🌙' : '☀️'}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a `ThemeToggle` button to switch between light and dark modes
- create a `Header` with sticky layout and toggle
- integrate the header in the root layout
- add gradient background and smoother font settings
- clean up duplicate page heading

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f63350c8883309c32b5eed166dbac